### PR TITLE
Add driver constructor support

### DIFF
--- a/.changeset/tired-coins-return.md
+++ b/.changeset/tired-coins-return.md
@@ -1,0 +1,5 @@
+---
+"valkeyrie": patch
+---
+
+Add driver constructor support

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is still a work in progress, but the API and everything already implemented
 - **Automatic type inference** - Full TypeScript support with schema-based type inference across all operations
 - **Atomic operations** - Perform multiple operations in a single transaction with optimistic locking
 - **Real-time updates** - Watch keys for changes with the `watch()` API
-- **Pluggable storage drivers** - Currently SQLite-based, with support for more drivers coming soon. Custom drivers are reachable today via the public `openWithDriver()` API and the `driverFn` option in factory methods.
+- **Pluggable storage drivers** - Currently SQLite-based, with support for more drivers coming soon. Custom drivers are reachable today by passing a driver function to the public `open()` API and via the `driverFn` option in factory methods.
 - **Rich data type support** - Store objects, arrays, dates, binary data, Maps, Sets, and more
 - **Hierarchical keys** - Organize data with multi-part keys for efficient querying
 - **Efficient querying** - List data with prefix and range queries

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is still a work in progress, but the API and everything already implemented
 - **Automatic type inference** - Full TypeScript support with schema-based type inference across all operations
 - **Atomic operations** - Perform multiple operations in a single transaction with optimistic locking
 - **Real-time updates** - Watch keys for changes with the `watch()` API
-- **Pluggable storage drivers** - Currently SQLite-based, with support for more drivers coming soon
+- **Pluggable storage drivers** - Currently SQLite-based, with support for more drivers coming soon. Custom drivers are reachable today via the public `openWithDriver()` API and the `driverFn` option in factory methods.
 - **Rich data type support** - Store objects, arrays, dates, binary data, Maps, Sets, and more
 - **Hierarchical keys** - Organize data with multi-part keys for efficient querying
 - **Efficient querying** - List data with prefix and range queries

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Feature-specific guides for different use cases:
   - Streaming data with `fromAsync()`
   - Progress tracking and error handling
   - Real-world import/migration examples
+  - Custom drivers via `openWithDriver()` and the `driverFn` option
 
 - **[Serializers](./guides/serializers.md)**
   - Choosing the right serializer

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Feature-specific guides for different use cases:
   - Streaming data with `fromAsync()`
   - Progress tracking and error handling
   - Real-world import/migration examples
-  - Custom drivers via `openWithDriver()` and the `driverFn` option
+  - Custom drivers by passing a driver function to `open()` and the `driverFn` option
 
 - **[Serializers](./guides/serializers.md)**
   - Choosing the right serializer

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -87,6 +87,43 @@ const db3 = await Valkeyrie.open('./temp.db', {
 
 ---
 
+#### `Valkeyrie.openWithDriver()`
+
+Open a database using a custom storage driver function. Use this when you need to supply a custom or pre-configured backend instead of a plain file path.
+
+```typescript
+static async openWithDriver(
+  driverFn: (serializer?: () => Serializer) => Promise<Driver>,
+  options?: {
+    serializer?: () => Serializer;
+    destroyOnClose?: boolean;
+  }
+): Promise<Valkeyrie>
+```
+
+**Parameters:**
+- `driverFn` - A function that receives the resolved serializer factory and returns a `Promise<Driver>`. Implement the `Driver` interface (import `Driver` type and `defineDriver` helper from `'valkeyrie/driver'`) for your own backend.
+- `options` - Configuration options
+  - `serializer` - Custom serializer factory (default: V8 serializer). Passed through to `driverFn`.
+  - `destroyOnClose` - Delete the underlying storage on close (default: `false`)
+
+**Returns:** `Promise<Valkeyrie>`
+
+> For the built-in SQLite backend use `Valkeyrie.open(path)` instead — `openWithDriver` is for custom backends only.
+
+**Example:**
+```typescript
+import { Valkeyrie } from 'valkeyrie';
+// `Driver` type and `defineDriver` helper are available from 'valkeyrie/driver'
+
+// `createMyDriver` returns an object implementing the Driver interface
+const db = await Valkeyrie.openWithDriver(
+  async (serializer) => createMyDriver(serializer),
+);
+```
+
+---
+
 #### `Valkeyrie.from()`
 
 Create and populate a database from a synchronous iterable.
@@ -100,14 +137,15 @@ static async from<T>(
 
 **Parameters:**
 - `iterable` - Array, Set, Map, or any iterable
-- `options` - Configuration options
+- `options` - Configuration options. Supplying `driverFn` uses a custom driver and takes precedence over `path`.
 
 **FromOptions:**
 ```typescript
 interface FromOptions<T> {
   prefix: Key;                                    // Required
   keyProperty: keyof T | ((item: T) => KeyPart);  // Required
-  path?: string;
+  path?: string;                                  // defaults to in-memory if neither path nor driverFn are given
+  driverFn?: (serializer?: () => Serializer) => Promise<Driver>; // takes precedence over path
   serializer?: () => Serializer;
   destroyOnClose?: boolean;
   expireIn?: number;
@@ -146,7 +184,7 @@ static async fromAsync<T>(
 ): Promise<Valkeyrie>
 ```
 
-**Parameters:** Same as `from()`
+**Parameters:** Same as `from()`. Supplying `driverFn` in options uses a custom driver and takes precedence over `path`.
 
 **Returns:** `Promise<Valkeyrie>`
 

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -50,11 +50,22 @@ const db = await Valkeyrie
 
 #### `Valkeyrie.open()`
 
-Open or create a database.
+Open or create a database. The first argument is either a file path for the
+built-in SQLite backend, or a driver factory function for a custom backend.
 
 ```typescript
+// Built-in SQLite backend (in-memory when path is omitted)
 static async open(
   path?: string,
+  options?: {
+    serializer?: () => Serializer;
+    destroyOnClose?: boolean;
+  }
+): Promise<Valkeyrie>
+
+// Custom backend
+static async open(
+  driverFn: DriverFactory, // (serializer?: () => Serializer) => Promise<Driver>
   options?: {
     serializer?: () => Serializer;
     destroyOnClose?: boolean;
@@ -64,9 +75,10 @@ static async open(
 
 **Parameters:**
 - `path` - Optional file path. Omit for in-memory database
+- `driverFn` - A `DriverFactory`: a function that receives the resolved serializer factory and returns a `Promise<Driver>`. Implement the `Driver` interface (import the `Driver` type and `defineDriver` helper from `'valkeyrie/driver'`) for your own backend.
 - `options` - Configuration options
-  - `serializer` - Custom serializer (default: V8 serializer)
-  - `destroyOnClose` - Delete database file on close (default: `false`)
+  - `serializer` - Custom serializer (default: V8 serializer). Passed through to `driverFn` when a custom backend is used.
+  - `destroyOnClose` - Delete the underlying storage on close (default: `false`)
 
 **Returns:** `Promise<Valkeyrie>`
 
@@ -83,41 +95,10 @@ const db3 = await Valkeyrie.open('./temp.db', {
   serializer: jsonSerializer,
   destroyOnClose: true
 });
-```
 
----
-
-#### `Valkeyrie.openWithDriver()`
-
-Open a database using a custom storage driver function. Use this when you need to supply a custom or pre-configured backend instead of a plain file path.
-
-```typescript
-static async openWithDriver(
-  driverFn: (serializer?: () => Serializer) => Promise<Driver>,
-  options?: {
-    serializer?: () => Serializer;
-    destroyOnClose?: boolean;
-  }
-): Promise<Valkeyrie>
-```
-
-**Parameters:**
-- `driverFn` - A function that receives the resolved serializer factory and returns a `Promise<Driver>`. Implement the `Driver` interface (import `Driver` type and `defineDriver` helper from `'valkeyrie/driver'`) for your own backend.
-- `options` - Configuration options
-  - `serializer` - Custom serializer factory (default: V8 serializer). Passed through to `driverFn`.
-  - `destroyOnClose` - Delete the underlying storage on close (default: `false`)
-
-**Returns:** `Promise<Valkeyrie>`
-
-> For the built-in SQLite backend use `Valkeyrie.open(path)` instead — `openWithDriver` is for custom backends only.
-
-**Example:**
-```typescript
-import { Valkeyrie } from 'valkeyrie';
-// `Driver` type and `defineDriver` helper are available from 'valkeyrie/driver'
-
-// `createMyDriver` returns an object implementing the Driver interface
-const db = await Valkeyrie.openWithDriver(
+// Custom backend — `createMyDriver` returns an object implementing the Driver
+// interface (the `Driver` type and `defineDriver` helper live in 'valkeyrie/driver')
+const db4 = await Valkeyrie.open(
   async (serializer) => createMyDriver(serializer),
 );
 ```

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -233,7 +233,8 @@ Same as `Check` but used in the atomic operation builder.
 interface FromOptions<T> {
   prefix: Key;
   keyProperty: keyof T | ((item: T) => KeyPart);
-  path?: string;
+  path?: string;                                                   // defaults to in-memory if neither path nor driverFn are given
+  driverFn?: (serializer?: () => Serializer) => Promise<Driver>;  // takes precedence over path
   serializer?: () => Serializer;
   destroyOnClose?: boolean;
   expireIn?: number;

--- a/docs/guides/factory-methods.md
+++ b/docs/guides/factory-methods.md
@@ -265,12 +265,29 @@ Both `from()` and `fromAsync()` accept the same options:
 | `prefix` | `Key` | **Yes** | Key prefix for all entries (e.g., `['users']`) |
 | `keyProperty` | `keyof T \| (item: T) => KeyPart` | **Yes** | Property name or function to extract key part |
 | `path` | `string` | No | Database file path. If omitted, creates in-memory database |
+| `driverFn` | `(serializer?: () => Serializer) => Promise<Driver>` | No | Custom driver function. Takes precedence over `path` |
 | `serializer` | `() => Serializer` | No | Custom serializer (default: v8 serializer) |
 | `destroyOnClose` | `boolean` | No | Destroy database file on close (default: `false`) |
 | `expireIn` | `number` | No | TTL for all entries in milliseconds |
 | `onProgress` | `(processed: number, total?: number) => void` | No | Progress callback. `total` is only provided for sync iterables with known size |
 | `onError` | `'stop' \| 'continue'` | No | Error handling strategy (default: `'stop'`) |
 | `onErrorCallback` | `(error: Error, item: T) => void` | No | Called for each error when `onError: 'continue'` |
+
+### Custom Drivers
+
+For advanced use cases, supply a custom driver via `driverFn` instead of `path`. The driver function receives the resolved serializer factory and returns a `Driver` instance. The `Driver` type and `defineDriver` helper for authoring your own backend are available from `'valkeyrie/driver'`. Omitting `driverFn` and using `path` (or neither) keeps the built-in SQLite driver.
+
+```typescript
+import { Valkeyrie } from 'valkeyrie';
+// `Driver` type and `defineDriver` helper from 'valkeyrie/driver'
+
+// `createMyDriver` returns an object implementing the Driver interface
+const db = await Valkeyrie.from(users, {
+  prefix: ['users'],
+  keyProperty: 'id',
+  driverFn: async (serializer) => createMyDriver(serializer),
+});
+```
 
 ## Key Extraction
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -60,7 +60,7 @@ await db.close();
 
 ### Custom Driver
 
-Advanced users can supply a fully custom storage backend using `Valkeyrie.openWithDriver()` (or the `driverFn` option in factory methods). The `Driver` type and `defineDriver` helper for implementing a backend are exported from `'valkeyrie/driver'`. See the [API Reference](../api/api-reference.md#valkeyrieopenwithdriver) for details. For the built-in SQLite backend, `Valkeyrie.open(path)` is all you need.
+Advanced users can supply a fully custom storage backend by passing a driver function to `Valkeyrie.open()` (or via the `driverFn` option in factory methods) instead of a file path. The `Driver` type and `defineDriver` helper for implementing a backend are exported from `'valkeyrie/driver'`. See the [API Reference](../api/api-reference.md#valkeyrieopen) for details. For the built-in SQLite backend, just pass a path (or nothing) to `Valkeyrie.open()`.
 
 ### File-Based Database
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -58,6 +58,10 @@ const db = await Valkeyrie.open();
 await db.close();
 ```
 
+### Custom Driver
+
+Advanced users can supply a fully custom storage backend using `Valkeyrie.openWithDriver()` (or the `driverFn` option in factory methods). The `Driver` type and `defineDriver` helper for implementing a backend are exported from `'valkeyrie/driver'`. See the [API Reference](../api/api-reference.md#valkeyrieopenwithdriver) for details. For the built-in SQLite backend, `Valkeyrie.open(path)` is all you need.
+
 ### File-Based Database
 
 For persistent data that survives restarts:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ features:
 
   - icon: 🔌
     title: Pluggable Storage Drivers
-    details: Built on SQLite with a driver architecture designed for extensibility. More drivers coming soon.
+    details: Built on SQLite with a driver architecture designed for extensibility. Custom drivers are already accessible via the public `openWithDriver()` API and the `driverFn` option in factory methods. More built-in drivers coming soon.
 
   - icon: 🔒
     title: Multi-instance Safe

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ features:
 
   - icon: 🔌
     title: Pluggable Storage Drivers
-    details: Built on SQLite with a driver architecture designed for extensibility. Custom drivers are already accessible via the public `openWithDriver()` API and the `driverFn` option in factory methods. More built-in drivers coming soon.
+    details: Built on SQLite with a driver architecture designed for extensibility. Custom drivers are already accessible by passing a driver function to the public `open()` API and via the `driverFn` option in factory methods. More built-in drivers coming soon.
 
   - icon: 🔒
     title: Multi-instance Safe

--- a/src/valkeyrie-builder.ts
+++ b/src/valkeyrie-builder.ts
@@ -1,6 +1,8 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
+import type { Driver } from './driver.ts'
 import { SchemaRegistry } from './schema-registry.ts'
 import type { Serializer } from './serializers/serializer.ts'
+import { sqliteDriver } from './sqlite-driver.ts'
 import { kFrom, kFromAsync, kOpen } from './symbols.ts'
 import type {
   SchemaRegistryEntry,
@@ -69,7 +71,27 @@ export class ValkeyrieBuilder<
     } = {},
   ): Promise<Valkeyrie<TRegistry>> {
     return Valkeyrie[kOpen](
-      path,
+      (serializer?: () => Serializer) => sqliteDriver(path, serializer),
+      options,
+      this.schemaRegistry,
+    ) as unknown as Promise<Valkeyrie<TRegistry>>
+  }
+
+  /**
+   * Opens a new Valkeyrie database instance with registered schemas.
+   * @param path Optional path to the database file (defaults to in-memory)
+   * @param options Optional configuration options
+   * @returns A new Valkeyrie instance with schema validation and type inference
+   */
+  async openWithDriver(
+    driverFn: (serializer?: () => Serializer) => Promise<Driver>,
+    options: {
+      serializer?: () => Serializer
+      destroyOnClose?: boolean
+    } = {},
+  ): Promise<Valkeyrie<TRegistry>> {
+    return Valkeyrie[kOpen](
+      driverFn,
       options,
       this.schemaRegistry,
     ) as unknown as Promise<Valkeyrie<TRegistry>>

--- a/src/valkeyrie-builder.ts
+++ b/src/valkeyrie-builder.ts
@@ -1,5 +1,4 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { Driver } from './driver.ts'
 import { SchemaRegistry } from './schema-registry.ts'
 import type { Serializer } from './serializers/serializer.ts'
 import { sqliteDriver } from './sqlite-driver.ts'
@@ -8,7 +7,7 @@ import type {
   SchemaRegistryEntry,
   SchemaRegistry as SchemaRegistryType,
 } from './types/schema-registry-types.ts'
-import type { FromOptions, Key } from './valkeyrie.ts'
+import type { DriverFactory, FromOptions, Key } from './valkeyrie.ts'
 import { Valkeyrie } from './valkeyrie.ts'
 
 /**
@@ -59,44 +58,48 @@ export class ValkeyrieBuilder<
 
   /**
    * Opens a new Valkeyrie database instance with registered schemas.
+   *
+   * Accepts either a file path for the built-in SQLite backend, or a
+   * {@link DriverFactory} to supply a custom storage backend. Omit the argument
+   * for an in-memory SQLite database.
+   *
    * @param path Optional path to the database file (defaults to in-memory)
    * @param options Optional configuration options
    * @returns A new Valkeyrie instance with schema validation and type inference
    */
   async open(
     path?: string,
-    options: {
+    options?: {
       serializer?: () => Serializer
       destroyOnClose?: boolean
-    } = {},
-  ): Promise<Valkeyrie<TRegistry>> {
-    return Valkeyrie[kOpen](
-      (serializer?: () => Serializer) => sqliteDriver(path, serializer),
-      options,
-      this.schemaRegistry,
-    ) as unknown as Promise<Valkeyrie<TRegistry>>
-  }
-
+    },
+  ): Promise<Valkeyrie<TRegistry>>
   /**
    * Opens a new Valkeyrie database instance backed by a custom driver,
    * with registered schemas.
-   *
-   * Use this instead of {@link ValkeyrieBuilder.open} to supply your own storage
-   * backend. The driver function receives the configured serializer (if any) and
-   * must resolve to a {@link Driver}. For the built-in SQLite backend, prefer
-   * {@link ValkeyrieBuilder.open}.
    *
    * @param driverFn Function that creates the driver, optionally using the serializer
    * @param options Optional configuration options
    * @returns A new Valkeyrie instance with schema validation and type inference
    */
-  async openWithDriver(
-    driverFn: (serializer?: () => Serializer) => Promise<Driver>,
+  async open(
+    driverFn: DriverFactory,
+    options?: {
+      serializer?: () => Serializer
+      destroyOnClose?: boolean
+    },
+  ): Promise<Valkeyrie<TRegistry>>
+  async open(
+    pathOrDriver?: string | DriverFactory,
     options: {
       serializer?: () => Serializer
       destroyOnClose?: boolean
     } = {},
   ): Promise<Valkeyrie<TRegistry>> {
+    const driverFn: DriverFactory =
+      typeof pathOrDriver === 'function'
+        ? pathOrDriver
+        : (serializer) => sqliteDriver(pathOrDriver, serializer)
     return Valkeyrie[kOpen](
       driverFn,
       options,

--- a/src/valkeyrie-builder.ts
+++ b/src/valkeyrie-builder.ts
@@ -78,8 +78,15 @@ export class ValkeyrieBuilder<
   }
 
   /**
-   * Opens a new Valkeyrie database instance with registered schemas.
-   * @param path Optional path to the database file (defaults to in-memory)
+   * Opens a new Valkeyrie database instance backed by a custom driver,
+   * with registered schemas.
+   *
+   * Use this instead of {@link ValkeyrieBuilder.open} to supply your own storage
+   * backend. The driver function receives the configured serializer (if any) and
+   * must resolve to a {@link Driver}. For the built-in SQLite backend, prefer
+   * {@link ValkeyrieBuilder.open}.
+   *
+   * @param driverFn Function that creates the driver, optionally using the serializer
    * @param options Optional configuration options
    * @returns A new Valkeyrie instance with schema validation and type inference
    */

--- a/src/valkeyrie.ts
+++ b/src/valkeyrie.ts
@@ -166,8 +166,22 @@ export class Valkeyrie<TRegistry extends SchemaRegistryType = readonly []> {
   }
 
   /**
-   * Opens a new Valkeyrie database instance
-   * @param path Optional path to the database file (defaults to in-memory)
+   * Opens a new Valkeyrie database instance backed by a custom driver.
+   *
+   * Use this instead of {@link Valkeyrie.open} when you want to supply your own
+   * storage backend. The driver function receives the configured serializer
+   * (if any) and must resolve to a {@link Driver}. For the built-in SQLite
+   * backend, prefer {@link Valkeyrie.open}.
+   *
+   * @example
+   * ```typescript
+   * // `createMyDriver` returns an object implementing the Driver interface
+   * const db = await Valkeyrie.openWithDriver(
+   *   async (serializer) => createMyDriver(serializer),
+   * )
+   * ```
+   *
+   * @param driverFn Function that creates the driver, optionally using the serializer
    * @param options Optional configuration options
    * @returns A new Valkeyrie instance
    */

--- a/src/valkeyrie.ts
+++ b/src/valkeyrie.ts
@@ -55,8 +55,10 @@ export interface FromOptions<T> {
   prefix: Key
   /** Property name or function to extract the key part from each item */
   keyProperty: keyof T | ((item: T) => KeyPart)
-  /** Optional path to the database file (defaults to in-memory) */
+  /** Optional path to the database file (defaults to in-memory if neither path nor driverFn are given) */
   path?: string
+  /** Optional function to provide a driver; takes precedence over path */
+  driverFn?: (serializer?: () => Serializer) => Promise<Driver>
   /** Optional custom serializer */
   serializer?: () => Serializer
   /** Optional destroyOnClose flag (default: false) */
@@ -157,7 +159,26 @@ export class Valkeyrie<TRegistry extends SchemaRegistryType = readonly []> {
       destroyOnClose?: boolean
     } = {},
   ): Promise<Valkeyrie> {
-    return Valkeyrie[kOpen](path, options, undefined)
+    return Valkeyrie.openWithDriver(
+      (serializer?: () => Serializer) => sqliteDriver(path, serializer),
+      options,
+    )
+  }
+
+  /**
+   * Opens a new Valkeyrie database instance
+   * @param path Optional path to the database file (defaults to in-memory)
+   * @param options Optional configuration options
+   * @returns A new Valkeyrie instance
+   */
+  public static async openWithDriver(
+    driverFn: (serializer?: () => Serializer) => Promise<Driver>,
+    options: {
+      serializer?: () => Serializer
+      destroyOnClose?: boolean
+    } = {},
+  ): Promise<Valkeyrie> {
+    return Valkeyrie[kOpen](driverFn, options, undefined)
   }
 
   /**
@@ -165,7 +186,7 @@ export class Valkeyrie<TRegistry extends SchemaRegistryType = readonly []> {
    * Used by ValkeyrieBuilder.
    */
   static async [kOpen](
-    path?: string,
+    driverFn: (serializer?: () => Serializer) => Promise<Driver>,
     options: {
       serializer?: () => Serializer
       destroyOnClose?: boolean
@@ -183,7 +204,7 @@ export class Valkeyrie<TRegistry extends SchemaRegistryType = readonly []> {
       constructorOptions.schemaRegistry = schemaRegistry
     }
     const db = new Valkeyrie(
-      await sqliteDriver(path, options.serializer),
+      await driverFn(options.serializer),
       constructorOptions,
       kValkeyrie,
     )
@@ -264,8 +285,14 @@ export class Valkeyrie<TRegistry extends SchemaRegistryType = readonly []> {
     if (options.destroyOnClose !== undefined) {
       openOptions.destroyOnClose = options.destroyOnClose
     }
+    let driverFn = options.driverFn
+    if (driverFn === undefined) {
+      driverFn = (serializer?: () => Serializer) =>
+        sqliteDriver(options.path, serializer)
+    }
+
     const db: Valkeyrie = await Valkeyrie[kOpen](
-      options.path,
+      driverFn,
       openOptions,
       schemaRegistry,
     )
@@ -392,8 +419,14 @@ export class Valkeyrie<TRegistry extends SchemaRegistryType = readonly []> {
     if (options.destroyOnClose !== undefined) {
       openOptions.destroyOnClose = options.destroyOnClose
     }
+    let driverFn = options.driverFn
+    if (driverFn === undefined) {
+      driverFn = (serializer?: () => Serializer) =>
+        sqliteDriver(options.path, serializer)
+    }
+
     const db: Valkeyrie = await Valkeyrie[kOpen](
-      options.path,
+      driverFn,
       openOptions,
       schemaRegistry,
     )

--- a/src/valkeyrie.ts
+++ b/src/valkeyrie.ts
@@ -48,6 +48,13 @@ interface SetOptions {
 }
 
 /**
+ * Factory that creates a storage {@link Driver}, optionally using the configured
+ * serializer. Pass one to {@link Valkeyrie.open} (or via `FromOptions.driverFn`)
+ * to back a database with a custom storage engine instead of the built-in SQLite.
+ */
+export type DriverFactory = (serializer?: () => Serializer) => Promise<Driver>
+
+/**
  * Options for creating a Valkeyrie database from an iterable.
  */
 export interface FromOptions<T> {
@@ -58,7 +65,7 @@ export interface FromOptions<T> {
   /** Optional path to the database file (defaults to in-memory if neither path nor driverFn are given) */
   path?: string
   /** Optional function to provide a driver; takes precedence over path */
-  driverFn?: (serializer?: () => Serializer) => Promise<Driver>
+  driverFn?: DriverFactory
   /** Optional custom serializer */
   serializer?: () => Serializer
   /** Optional destroyOnClose flag (default: false) */
@@ -147,51 +154,58 @@ export class Valkeyrie<TRegistry extends SchemaRegistryType = readonly []> {
   }
 
   /**
-   * Opens a new Valkeyrie database instance
+   * Opens a new Valkeyrie database instance.
+   *
+   * Accepts either a file path for the built-in SQLite backend, or a
+   * {@link DriverFactory} to supply a custom storage backend. Omit the argument
+   * for an in-memory SQLite database.
+   *
+   * @example
+   * ```typescript
+   * // Built-in SQLite (in-memory or file path)
+   * const memory = await Valkeyrie.open()
+   * const file = await Valkeyrie.open('./data.db')
+   *
+   * // Custom backend: `createMyDriver` returns an object implementing Driver
+   * const custom = await Valkeyrie.open(async (serializer) => createMyDriver(serializer))
+   * ```
+   *
    * @param path Optional path to the database file (defaults to in-memory)
    * @param options Optional configuration options
    * @returns A new Valkeyrie instance
    */
   public static async open(
     path?: string,
-    options: {
+    options?: {
       serializer?: () => Serializer
       destroyOnClose?: boolean
-    } = {},
-  ): Promise<Valkeyrie> {
-    return Valkeyrie.openWithDriver(
-      (serializer?: () => Serializer) => sqliteDriver(path, serializer),
-      options,
-    )
-  }
-
+    },
+  ): Promise<Valkeyrie>
   /**
    * Opens a new Valkeyrie database instance backed by a custom driver.
-   *
-   * Use this instead of {@link Valkeyrie.open} when you want to supply your own
-   * storage backend. The driver function receives the configured serializer
-   * (if any) and must resolve to a {@link Driver}. For the built-in SQLite
-   * backend, prefer {@link Valkeyrie.open}.
-   *
-   * @example
-   * ```typescript
-   * // `createMyDriver` returns an object implementing the Driver interface
-   * const db = await Valkeyrie.openWithDriver(
-   *   async (serializer) => createMyDriver(serializer),
-   * )
-   * ```
    *
    * @param driverFn Function that creates the driver, optionally using the serializer
    * @param options Optional configuration options
    * @returns A new Valkeyrie instance
    */
-  public static async openWithDriver(
-    driverFn: (serializer?: () => Serializer) => Promise<Driver>,
+  public static async open(
+    driverFn: DriverFactory,
+    options?: {
+      serializer?: () => Serializer
+      destroyOnClose?: boolean
+    },
+  ): Promise<Valkeyrie>
+  public static async open(
+    pathOrDriver?: string | DriverFactory,
     options: {
       serializer?: () => Serializer
       destroyOnClose?: boolean
     } = {},
   ): Promise<Valkeyrie> {
+    const driverFn: DriverFactory =
+      typeof pathOrDriver === 'function'
+        ? pathOrDriver
+        : (serializer) => sqliteDriver(pathOrDriver, serializer)
     return Valkeyrie[kOpen](driverFn, options, undefined)
   }
 
@@ -200,7 +214,7 @@ export class Valkeyrie<TRegistry extends SchemaRegistryType = readonly []> {
    * Used by ValkeyrieBuilder.
    */
   static async [kOpen](
-    driverFn: (serializer?: () => Serializer) => Promise<Driver>,
+    driverFn: DriverFactory,
     options: {
       serializer?: () => Serializer
       destroyOnClose?: boolean

--- a/test/valkeyrie-builder.ts
+++ b/test/valkeyrie-builder.ts
@@ -161,12 +161,12 @@ describe('ValkeyrieBuilder', () => {
     })
   })
 
-  describe('openWithDriver() Method', () => {
+  describe('open() with a driver function', () => {
     test('returns a working Valkeyrie instance from a custom driver', async () => {
       const builder = new ValkeyrieBuilder()
       const spy: DriverSpy = { created: 0 }
 
-      const db = await builder.openWithDriver(createSpyDriverFn(spy))
+      const db = await builder.open(createSpyDriverFn(spy))
 
       assert.ok(db instanceof Valkeyrie)
       assert.strictEqual(spy.created, 1)
@@ -182,7 +182,7 @@ describe('ValkeyrieBuilder', () => {
       builder.withSchema(['users', '*'], schema)
       const spy: DriverSpy = { created: 0 }
 
-      const db = await builder.openWithDriver(createSpyDriverFn(spy))
+      const db = await builder.open(createSpyDriverFn(spy))
 
       assert.ok(db instanceof Valkeyrie)
       assert.strictEqual(spy.created, 1)

--- a/test/valkeyrie-builder.ts
+++ b/test/valkeyrie-builder.ts
@@ -1,6 +1,13 @@
 import assert from 'node:assert'
+import { randomUUID } from 'node:crypto'
+import { access } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, test } from 'node:test'
 import type { StandardSchemaV1 } from '@standard-schema/spec'
+import type { Driver } from '../src/driver.ts'
+import type { Serializer } from '../src/serializers/serializer.ts'
+import { sqliteDriver } from '../src/sqlite-driver.ts'
 import { ValkeyrieBuilder } from '../src/valkeyrie-builder.ts'
 import { Valkeyrie } from '../src/valkeyrie.ts'
 
@@ -17,6 +24,17 @@ const createMockSchema = (name: string): StandardSchemaV1 =>
     },
     _name: name,
   }) as unknown as StandardSchemaV1
+
+// Spy wrapping the built-in in-memory driver, used to verify a custom
+// driverFn is actually invoked through the builder.
+type DriverSpy = { created: number }
+
+const createSpyDriverFn =
+  (spy: DriverSpy) =>
+  async (serializer?: () => Serializer): Promise<Driver> => {
+    spy.created += 1
+    return sqliteDriver(':memory:', serializer)
+  }
 
 describe('ValkeyrieBuilder', () => {
   describe('Builder Construction', () => {
@@ -143,6 +161,35 @@ describe('ValkeyrieBuilder', () => {
     })
   })
 
+  describe('openWithDriver() Method', () => {
+    test('returns a working Valkeyrie instance from a custom driver', async () => {
+      const builder = new ValkeyrieBuilder()
+      const spy: DriverSpy = { created: 0 }
+
+      const db = await builder.openWithDriver(createSpyDriverFn(spy))
+
+      assert.ok(db instanceof Valkeyrie)
+      assert.strictEqual(spy.created, 1)
+      await db.set(['k'], 'v')
+      const entry = await db.get(['k'])
+      assert.strictEqual(entry.value, 'v')
+      await db.close()
+    })
+
+    test('applies registered schemas through the custom driver', async () => {
+      const builder = new ValkeyrieBuilder()
+      const schema = createMockSchema('user')
+      builder.withSchema(['users', '*'], schema)
+      const spy: DriverSpy = { created: 0 }
+
+      const db = await builder.openWithDriver(createSpyDriverFn(spy))
+
+      assert.ok(db instanceof Valkeyrie)
+      assert.strictEqual(spy.created, 1)
+      await db.close()
+    })
+  })
+
   describe('from() Method', () => {
     test('returns a Valkeyrie instance', async () => {
       const builder = new ValkeyrieBuilder()
@@ -211,6 +258,26 @@ describe('ValkeyrieBuilder', () => {
       })
 
       assert.ok(db instanceof Valkeyrie)
+      await db.close()
+    })
+
+    test('uses driverFn over path when both are provided', async () => {
+      const builder = new ValkeyrieBuilder()
+      const spy: DriverSpy = { created: 0 }
+      const testPath = join(tmpdir(), `builder-from-${randomUUID()}.db`)
+
+      const db = await builder.from([{ id: 1, value: 'a' }], {
+        prefix: ['items'],
+        keyProperty: 'id',
+        path: testPath,
+        driverFn: createSpyDriverFn(spy),
+      })
+
+      assert.ok(db instanceof Valkeyrie)
+      assert.strictEqual(spy.created, 1)
+      const item = await db.get(['items', 1])
+      assert.deepEqual(item.value, { id: 1, value: 'a' })
+      await assert.rejects(access(testPath))
       await db.close()
     })
   })
@@ -298,6 +365,30 @@ describe('ValkeyrieBuilder', () => {
       })
 
       assert.ok(db instanceof Valkeyrie)
+      await db.close()
+    })
+
+    test('uses driverFn over path when both are provided', async () => {
+      const builder = new ValkeyrieBuilder()
+      const spy: DriverSpy = { created: 0 }
+      const testPath = join(tmpdir(), `builder-fromasync-${randomUUID()}.db`)
+
+      async function* generate() {
+        yield { id: 1, value: 'a' }
+      }
+
+      const db = await builder.fromAsync(generate(), {
+        prefix: ['items'],
+        keyProperty: 'id',
+        path: testPath,
+        driverFn: createSpyDriverFn(spy),
+      })
+
+      assert.ok(db instanceof Valkeyrie)
+      assert.strictEqual(spy.created, 1)
+      const item = await db.get(['items', 1])
+      assert.deepEqual(item.value, { id: 1, value: 'a' })
+      await assert.rejects(access(testPath))
       await db.close()
     })
   })

--- a/test/valkeyrie.ts
+++ b/test/valkeyrie.ts
@@ -7,7 +7,11 @@ import { describe, test } from 'node:test'
 import { setTimeout } from 'node:timers/promises'
 import { inspect } from 'node:util'
 import type { StandardSchemaV1 } from '@standard-schema/spec'
+import type { Driver } from '../src/driver.ts'
 import { KvU64 } from '../src/kv-u64.ts'
+import { jsonSerializer } from '../src/serializers/json.ts'
+import type { Serializer } from '../src/serializers/serializer.ts'
+import { sqliteDriver } from '../src/sqlite-driver.ts'
 import { ValkeyrieBuilder } from '../src/valkeyrie-builder.ts'
 import {
   AtomicOperation,
@@ -16,6 +20,39 @@ import {
   type Mutation,
   Valkeyrie,
 } from '../src/valkeyrie.ts'
+
+/**
+ * A spy that wraps the built-in in-memory SQLite driver so tests can assert the
+ * supplied `driverFn` was actually invoked and used. Mirrors how a consumer
+ * would provide a custom backend, without reimplementing the full Driver contract.
+ */
+type DriverSpy = {
+  created: number
+  serializerSeen: boolean
+  setCalls: number
+  getCalls: number
+}
+
+function createSpyDriverFn(
+  spy: DriverSpy,
+): (serializer?: () => Serializer) => Promise<Driver> {
+  return async (serializer?: () => Serializer): Promise<Driver> => {
+    spy.created += 1
+    spy.serializerSeen = serializer !== undefined
+    const inner = await sqliteDriver(':memory:', serializer)
+    return {
+      ...inner,
+      set: (...args: Parameters<Driver['set']>) => {
+        spy.setCalls += 1
+        return inner.set(...args)
+      },
+      get: (...args: Parameters<Driver['get']>) => {
+        spy.getCalls += 1
+        return inner.get(...args)
+      },
+    }
+  }
+}
 
 describe('test valkeyrie', async () => {
   async function dbTest(
@@ -3043,6 +3080,133 @@ describe('test valkeyrie', async () => {
         items.push(item)
       }
       assert.strictEqual(items.length, 0)
+    } finally {
+      await db.close()
+    }
+  })
+
+  await test('openWithDriver() opens a working database', async () => {
+    const spy: DriverSpy = {
+      created: 0,
+      serializerSeen: false,
+      setCalls: 0,
+      getCalls: 0,
+    }
+
+    const db = await Valkeyrie.openWithDriver(createSpyDriverFn(spy))
+
+    try {
+      await db.set(['greeting'], 'hello')
+      const entry = await db.get(['greeting'])
+      assert.strictEqual(entry.value, 'hello')
+      // The provided driver function was invoked and actually used
+      assert.strictEqual(spy.created, 1)
+      assert.ok(spy.setCalls > 0)
+      assert.ok(spy.getCalls > 0)
+    } finally {
+      await db.close()
+    }
+  })
+
+  await test('openWithDriver() passes the serializer to the driver function', async () => {
+    const spy: DriverSpy = {
+      created: 0,
+      serializerSeen: false,
+      setCalls: 0,
+      getCalls: 0,
+    }
+
+    const db = await Valkeyrie.openWithDriver(createSpyDriverFn(spy), {
+      serializer: jsonSerializer,
+    })
+
+    try {
+      assert.strictEqual(spy.serializerSeen, true)
+      await db.set(['k'], { a: 1 })
+      const entry = await db.get(['k'])
+      assert.deepEqual(entry.value, { a: 1 })
+    } finally {
+      await db.close()
+    }
+  })
+
+  await test('from() uses driverFn when provided', async () => {
+    const spy: DriverSpy = {
+      created: 0,
+      serializerSeen: false,
+      setCalls: 0,
+      getCalls: 0,
+    }
+
+    const items = [{ id: 1, value: 'a' }]
+    const db = await Valkeyrie.from(items, {
+      prefix: ['items'],
+      keyProperty: 'id',
+      driverFn: createSpyDriverFn(spy),
+    })
+
+    try {
+      assert.strictEqual(spy.created, 1)
+      const item = await db.get(['items', 1])
+      assert.deepEqual(item.value, { id: 1, value: 'a' })
+    } finally {
+      await db.close()
+    }
+  })
+
+  await test('from() with both path and driverFn uses driverFn and ignores path', async () => {
+    const spy: DriverSpy = {
+      created: 0,
+      serializerSeen: false,
+      setCalls: 0,
+      getCalls: 0,
+    }
+    const testPath = join(tmpdir(), `test-driverfn-${randomUUID()}.db`)
+
+    const items = [{ id: 1, value: 'a' }]
+    const db = await Valkeyrie.from(items, {
+      prefix: ['items'],
+      keyProperty: 'id',
+      path: testPath,
+      driverFn: createSpyDriverFn(spy),
+    })
+
+    try {
+      assert.strictEqual(spy.created, 1)
+      const item = await db.get(['items', 1])
+      assert.deepEqual(item.value, { id: 1, value: 'a' })
+      // driverFn takes precedence: the file at `path` is never created
+      await assert.rejects(access(testPath))
+    } finally {
+      await db.close()
+    }
+  })
+
+  await test('fromAsync() with both path and driverFn uses driverFn and ignores path', async () => {
+    const spy: DriverSpy = {
+      created: 0,
+      serializerSeen: false,
+      setCalls: 0,
+      getCalls: 0,
+    }
+    const testPath = join(tmpdir(), `test-driverfn-async-${randomUUID()}.db`)
+
+    async function* generate() {
+      yield { id: 1, value: 'a' }
+    }
+
+    const db = await Valkeyrie.fromAsync(generate(), {
+      prefix: ['items'],
+      keyProperty: 'id',
+      path: testPath,
+      driverFn: createSpyDriverFn(spy),
+    })
+
+    try {
+      assert.strictEqual(spy.created, 1)
+      const item = await db.get(['items', 1])
+      assert.deepEqual(item.value, { id: 1, value: 'a' })
+      await assert.rejects(access(testPath))
     } finally {
       await db.close()
     }

--- a/test/valkeyrie.ts
+++ b/test/valkeyrie.ts
@@ -3085,7 +3085,7 @@ describe('test valkeyrie', async () => {
     }
   })
 
-  await test('openWithDriver() opens a working database', async () => {
+  await test('open() with a driver function opens a working database', async () => {
     const spy: DriverSpy = {
       created: 0,
       serializerSeen: false,
@@ -3093,7 +3093,7 @@ describe('test valkeyrie', async () => {
       getCalls: 0,
     }
 
-    const db = await Valkeyrie.openWithDriver(createSpyDriverFn(spy))
+    const db = await Valkeyrie.open(createSpyDriverFn(spy))
 
     try {
       await db.set(['greeting'], 'hello')
@@ -3108,7 +3108,20 @@ describe('test valkeyrie', async () => {
     }
   })
 
-  await test('openWithDriver() passes the serializer to the driver function', async () => {
+  await test('open() with a string path still uses the built-in driver', async () => {
+    // Overloading open() to also accept a driver function must not break the path form
+    const db = await Valkeyrie.open(':memory:')
+
+    try {
+      await db.set(['greeting'], 'hello')
+      const entry = await db.get(['greeting'])
+      assert.strictEqual(entry.value, 'hello')
+    } finally {
+      await db.close()
+    }
+  })
+
+  await test('open() with a driver function passes the serializer to it', async () => {
     const spy: DriverSpy = {
       created: 0,
       serializerSeen: false,
@@ -3116,7 +3129,7 @@ describe('test valkeyrie', async () => {
       getCalls: 0,
     }
 
-    const db = await Valkeyrie.openWithDriver(createSpyDriverFn(spy), {
+    const db = await Valkeyrie.open(createSpyDriverFn(spy), {
       serializer: jsonSerializer,
     })
 


### PR DESCRIPTION
## In this PR:

- Allow opening a `Valkeyrie` instance (in any way: builder, schema, iterable, etc) with a custom driver rather than an optional string path.
- Does _not_ break the existing public API that allows passing just a string (or nothing); adds a new overload to `open()` and new options to `FromOptions` (builder, iterable) that take precedence over the path.
- This enables consumers to build their own driver (e.g. MongoDB, PostgreSQL) and then supply it to the constructors, fulfilling the feature promised in the readme.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/turborepo-remote-cache/pulls) for the same update/change?
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
* [x] Have you linted your code locally with `pnpm lint` before submission?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully built locally with `pnpm build`?
* [x] Have you successfully tested locally with `pnpm test`?
* [x] Have you committed using [Conventional Commits](https://github.com/ducktors/turborepo-remote-cache#how-to-commit)?
